### PR TITLE
Fix reference to event loop in serve_forever method

### DIFF
--- a/rloop/server.py
+++ b/rloop/server.py
@@ -27,7 +27,7 @@ class Server:
         #     raise RuntimeError(f'server {self!r} is closed')
 
         self._inner._start_serving()
-        self._sff = self._loop.create_future()
+        self._sff = self.get_loop().create_future()
 
         try:
             await self._sff

--- a/rloop/server.py
+++ b/rloop/server.py
@@ -27,7 +27,7 @@ class Server:
         #     raise RuntimeError(f'server {self!r} is closed')
 
         self._inner._start_serving()
-        self._sff = self.get_loop().create_future()
+        self._sff = self._inner._loop.create_future()
 
         try:
             await self._sff


### PR DESCRIPTION
This pull request includes a minor change to the `serve_forever` method in `rloop/server.py`. The change replaces the use of `self._loop.create_future()` with `self.get_loop().create_future()` to ensure compatibility with the loop retrieval method.

```python
import asyncio
import rloop
import traceback

async def start_server(host: str, port: int):
    server = await asyncio.start_server(
        lambda r, w: asyncio.Protocol().connection_made(w), host, port
    )
    try:
        async with server:
            await server.serve_forever()
    except Exception as e:
        traceback.print_exc()

if __name__ == "__main__":
    loop = rloop.new_event_loop()
    loop.run_until_complete(start_server("0.0.0.0", 8888))


```

Exception is:
 `
line 30, in serve_forever
    self._sff = self._loop.create_future()
                ^^^^^^^^^^
AttributeError: 'Server' object has no attribute '_loop'
`
