### PR TITLE
Implement UDP socket support and related transport management in the event loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ lint-rust:
 		-D warnings \
 		-W clippy::pedantic \
 		-W clippy::dbg_macro \
+		-A clippy::blocks_in_conditions \
 		-A clippy::cast-possible-truncation \
 		-A clippy::cast-sign-loss \
 		-A clippy::declare-interior-mutable-const \

--- a/rloop/loop.py
+++ b/rloop/loop.py
@@ -700,11 +700,7 @@ class RLoop(__BaseLoop, __asyncio.AbstractEventLoop):
                 raise ValueError('sock must be non-blocking')
 
         # Create the transport
-        transport, protocol = self._udp_conn(
-            (sock.fileno(), sock.family),
-            protocol_factory,
-            remote_addr
-        )
+        transport, protocol = self._udp_conn((sock.fileno(), sock.family), protocol_factory, remote_addr)
 
         # sock is now owned by the transport, prevent close
         sock.detach()

--- a/rloop/loop.py
+++ b/rloop/loop.py
@@ -693,9 +693,9 @@ class RLoop(__BaseLoop, __asyncio.AbstractEventLoop):
                 if not infos:
                     raise OSError('getaddrinfo() returned empty list')
                 if local_addr is not None:
-                    addr_info = (infos[0], infos[2], infos[4], None)
+                    addr_info = (infos[0][0], infos[0][2], infos[0][4], None)
                 if remote_addr is not None:
-                    addr_info = (infos[0], infos[2], None, infos[4])
+                    addr_info = (infos[0][0], infos[0][2], None, infos[0][4])
                 if not addr_info:
                     raise ValueError('can not get address information')
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,15 +8,19 @@ use std::os::windows::io::RawSocket;
 use mio::{Interest, Registry, Token, event::Source as MioSource, net::TcpListener};
 
 pub(crate) enum Source {
+    #[cfg(unix)]
+    FD(RawFd),
+    #[cfg(windows)]
+    FD(RawSocket),
     TCPListener(TcpListener),
     #[cfg(unix)]
     TCPStream(RawFd),
     #[cfg(windows)]
     TCPStream(RawSocket),
     #[cfg(unix)]
-    FD(RawFd),
+    UDPSocket(RawFd),
     #[cfg(windows)]
-    FD(RawSocket),
+    UDPSocket(RawSocket),
 }
 
 #[cfg(windows)]
@@ -43,36 +47,39 @@ impl MioSource for Source {
     #[inline]
     fn register(&mut self, registry: &Registry, token: Token, interests: Interest) -> std::io::Result<()> {
         match self {
-            Self::TCPListener(inner) => inner.register(registry, token, interests),
-            Self::TCPStream(inner) => SourceFd(inner).register(registry, token, interests),
             #[cfg(unix)]
             Self::FD(inner) => SourceFd(inner).register(registry, token, interests),
             #[cfg(windows)]
             Self::FD(inner) => SourceRawSocket(inner).register(registry, token, interests),
+            Self::TCPListener(inner) => inner.register(registry, token, interests),
+            Self::TCPStream(inner) => SourceFd(inner).register(registry, token, interests),
+            Self::UDPSocket(inner) => SourceFd(inner).register(registry, token, interests),
         }
     }
 
     #[inline]
     fn reregister(&mut self, registry: &Registry, token: Token, interests: Interest) -> std::io::Result<()> {
         match self {
-            Self::TCPListener(inner) => inner.reregister(registry, token, interests),
-            Self::TCPStream(inner) => SourceFd(inner).reregister(registry, token, interests),
             #[cfg(unix)]
             Self::FD(inner) => SourceFd(inner).reregister(registry, token, interests),
             #[cfg(windows)]
             Self::FD(inner) => SourceRawSocket(inner).register(registry, token, interests),
+            Self::TCPListener(inner) => inner.reregister(registry, token, interests),
+            Self::TCPStream(inner) => SourceFd(inner).reregister(registry, token, interests),
+            Self::UDPSocket(inner) => SourceFd(inner).reregister(registry, token, interests),
         }
     }
 
     #[inline]
     fn deregister(&mut self, registry: &Registry) -> std::io::Result<()> {
         match self {
-            Self::TCPListener(inner) => inner.deregister(registry),
-            Self::TCPStream(inner) => SourceFd(inner).deregister(registry),
             #[cfg(unix)]
             Self::FD(inner) => SourceFd(inner).deregister(registry),
             #[cfg(windows)]
             Self::FD(inner) => SourceRawSocket(inner).register(registry, token, interests),
+            Self::TCPListener(inner) => inner.deregister(registry),
+            Self::TCPStream(inner) => SourceFd(inner).deregister(registry),
+            Self::UDPSocket(inner) => SourceFd(inner).deregister(registry),
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,14 +13,14 @@ pub(crate) enum Source {
     #[cfg(windows)]
     FD(RawSocket),
     TCPListener(TcpListener),
-    #[cfg(unix)]
-    TCPStream(RawFd),
-    #[cfg(windows)]
-    TCPStream(RawSocket),
-    #[cfg(unix)]
-    UDPSocket(RawFd),
-    #[cfg(windows)]
-    UDPSocket(RawSocket),
+    // #[cfg(unix)]
+    // TCPStream(RawFd),
+    // #[cfg(windows)]
+    // TCPStream(RawSocket),
+    // #[cfg(unix)]
+    // UDPSocket(RawFd),
+    // #[cfg(windows)]
+    // UDPSocket(RawSocket),
 }
 
 #[cfg(windows)]
@@ -52,8 +52,6 @@ impl MioSource for Source {
             #[cfg(windows)]
             Self::FD(inner) => SourceRawSocket(inner).register(registry, token, interests),
             Self::TCPListener(inner) => inner.register(registry, token, interests),
-            Self::TCPStream(inner) => SourceFd(inner).register(registry, token, interests),
-            Self::UDPSocket(inner) => SourceFd(inner).register(registry, token, interests),
         }
     }
 
@@ -65,8 +63,6 @@ impl MioSource for Source {
             #[cfg(windows)]
             Self::FD(inner) => SourceRawSocket(inner).register(registry, token, interests),
             Self::TCPListener(inner) => inner.reregister(registry, token, interests),
-            Self::TCPStream(inner) => SourceFd(inner).reregister(registry, token, interests),
-            Self::UDPSocket(inner) => SourceFd(inner).reregister(registry, token, interests),
         }
     }
 
@@ -78,8 +74,6 @@ impl MioSource for Source {
             #[cfg(windows)]
             Self::FD(inner) => SourceRawSocket(inner).register(registry, token, interests),
             Self::TCPListener(inner) => inner.deregister(registry),
-            Self::TCPStream(inner) => SourceFd(inner).deregister(registry),
-            Self::UDPSocket(inner) => SourceFd(inner).deregister(registry),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod server;
 mod sock;
 mod tcp;
 mod time;
+mod udp;
 mod utils;
 
 pub(crate) fn get_lib_version() -> &'static str {

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,0 +1,249 @@
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+
+use mio::net::UdpSocket;
+use pyo3::{prelude::*, types::PyBytes, IntoPyObject};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::HashMap,
+    io::ErrorKind,
+    net::SocketAddr,
+    sync::atomic,
+};
+
+use crate::{
+    event_loop::{EventLoop, EventLoopRunState},
+    handles::Handle,
+    sock::SocketWrapper,
+};
+
+struct UDPTransportState {
+    socket: UdpSocket,
+    remote_addr: Option<SocketAddr>,
+}
+
+#[pyclass(frozen, unsendable, module = "rloop._rloop")]
+pub(crate) struct UDPTransport {
+    pub fd: usize,
+    state: RefCell<UDPTransportState>,
+    pyloop: Py<EventLoop>,
+    // atomics
+    closing: atomic::AtomicBool,
+    // py protocol fields
+    proto: PyObject,
+    protom_conn_lost: PyObject,
+    protom_datagram_received: PyObject,
+    protom_error_received: PyObject,
+    // py extras
+    extra: HashMap<String, PyObject>,
+    sock: Py<SocketWrapper>,
+}
+
+impl UDPTransport {
+    fn new(
+        py: Python,
+        pyloop: Py<EventLoop>,
+        socket: UdpSocket,
+        pyproto: Bound<PyAny>,
+        socket_family: i32,
+        remote_addr: Option<SocketAddr>,
+    ) -> Self {
+        let fd = socket.as_raw_fd() as usize;
+        let state = UDPTransportState {
+            socket,
+            remote_addr,
+        };
+
+        let protom_conn_lost = pyproto.getattr(pyo3::intern!(py, "connection_lost")).unwrap().unbind();
+        let protom_datagram_received = pyproto.getattr(pyo3::intern!(py, "datagram_received")).unwrap().unbind();
+        let protom_error_received = pyproto.getattr(pyo3::intern!(py, "error_received")).unwrap().unbind();
+        let proto = pyproto.unbind();
+
+        Self {
+            fd,
+            state: RefCell::new(state),
+            pyloop,
+            closing: false.into(),
+            proto,
+            protom_conn_lost,
+            protom_datagram_received,
+            protom_error_received,
+            extra: HashMap::new(),
+            sock: SocketWrapper::from_fd(py, fd, socket_family, socket2::Type::DGRAM, 0),
+        }
+    }
+
+    pub(crate) fn from_py(py: Python, pyloop: &Py<EventLoop>, pysock: (i32, i32), proto_factory: PyObject, remote_addr: Option<SocketAddr>) -> Self {
+        let sock = unsafe { socket2::Socket::from_raw_fd(pysock.0) };
+        _ = sock.set_nonblocking(true);
+        let std_socket: std::net::UdpSocket = sock.into();
+        let socket = UdpSocket::from_std(std_socket);
+
+        let proto = proto_factory.bind(py).call0().unwrap();
+
+        Self::new(py, pyloop.clone_ref(py), socket, proto, pysock.1, remote_addr)
+    }
+
+    pub(crate) fn attach(pyself: &Py<Self>, py: Python) -> PyResult<PyObject> {
+        let rself = pyself.borrow(py);
+        rself
+            .proto
+            .call_method1(py, pyo3::intern!(py, "connection_made"), (pyself.clone_ref(py),))?;
+        Ok(rself.proto.clone_ref(py))
+    }
+
+    #[inline]
+    fn call_conn_lost(&self, py: Python, exc: Option<PyErr>) {
+        _ = self.protom_conn_lost.call1(py, (exc,));
+    }
+
+    #[inline]
+    fn call_datagram_received(&self, py: Python, data: &[u8], addr: SocketAddr) {
+        let py_data = PyBytes::new(py, data);
+        let py_addr = (addr.ip().to_string(), addr.port()).into_pyobject(py).unwrap();
+        _ = self.protom_datagram_received.call1(py, (py_data, py_addr));
+    }
+
+    #[inline]
+    fn call_error_received(&self, py: Python, exc: PyErr) {
+        _ = self.protom_error_received.call1(py, (exc,));
+    }
+}
+
+#[pymethods]
+impl UDPTransport {
+    #[pyo3(signature = (name, default = None))]
+    fn get_extra_info(&self, py: Python, name: &str, default: Option<PyObject>) -> Option<PyObject> {
+        match name {
+            "socket" => Some(self.sock.clone_ref(py).into_any()),
+            "sockname" => self.sock.call_method0(py, pyo3::intern!(py, "getsockname")).ok(),
+            "peername" => {
+                if self.state.borrow().remote_addr.is_some() {
+                    self.sock.call_method0(py, pyo3::intern!(py, "getpeername")).ok()
+                } else {
+                    default
+                }
+            },
+            _ => self.extra.get(name).map(|v| v.clone_ref(py)).or(default),
+        }
+    }
+
+    fn is_closing(&self) -> bool {
+        self.closing.load(atomic::Ordering::Relaxed)
+    }
+
+    fn close(&self, py: Python) {
+        if self
+            .closing
+            .compare_exchange(false, true, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+
+        let event_loop = self.pyloop.get();
+        event_loop.udp_socket_rem(self.fd);
+        self.call_conn_lost(py, None);
+    }
+
+    fn abort(&self, py: Python) {
+        self.close(py);
+    }
+
+    fn set_protocol(&self, _protocol: PyObject) -> PyResult<()> {
+        Err(pyo3::exceptions::PyNotImplementedError::new_err(
+            "UDPTransport protocol cannot be changed",
+        ))
+    }
+
+    fn get_protocol(&self, py: Python) -> PyObject {
+        self.proto.clone_ref(py)
+    }
+
+    fn sendto(&self, py: Python, data: Cow<[u8]>, addr: Option<PyObject>) -> PyResult<()> {
+        if self.closing.load(atomic::Ordering::Relaxed) {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err("Cannot send on closing transport"));
+        }
+
+        let target_addr = match addr {
+            Some(addr_obj) => {
+                // Parse the address from Python tuple (host, port)
+                let addr_tuple: (String, u16) = addr_obj.extract(py)?;
+                Some(format!("{}:{}", addr_tuple.0, addr_tuple.1).parse::<SocketAddr>()
+                    .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid address: {}", e)))?)
+            },
+            None => {
+                // Get remote addr without holding the borrow longer than necessary
+                let remote_addr = self.state.borrow().remote_addr;
+                remote_addr
+            },
+        };
+
+        match target_addr {
+            Some(addr) => {
+                // Temporarily borrow just for the send operation
+                match self.state.borrow().socket.send_to(&data, addr) {
+                    Ok(_) => Ok(()),
+                    Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                        // For UDP, we don't buffer writes like TCP - just drop the packet or return error
+                        Err(pyo3::exceptions::PyBlockingIOError::new_err("Socket would block"))
+                    },
+                    Err(err) => Err(pyo3::exceptions::PyOSError::new_err(err.to_string())),
+                }
+            },
+            None => Err(pyo3::exceptions::PyValueError::new_err("No remote address specified")),
+        }
+    }
+}
+
+pub(crate) struct UDPHandle {
+    fd: usize,
+}
+
+impl UDPHandle {
+    pub(crate) fn new(fd: usize) -> Self {
+        Self { fd }
+    }
+}
+
+impl Handle for UDPHandle {
+    fn run(&self, py: Python, event_loop: &EventLoop, _state: &mut EventLoopRunState) {
+        let pytransport = event_loop.get_udp_transport(self.fd, py);
+        let transport = pytransport.borrow(py);
+
+        // Read datagrams from the socket
+        let mut buf = [0u8; 65536]; // Max UDP packet size
+
+        loop {
+            // Limit the scope of the borrow
+            let recv_result = {
+                let state = transport.state.borrow();
+                state.socket.recv_from(&mut buf)
+            };
+            
+            match recv_result {
+                Ok((size, addr)) => {
+                    // Call the protocol's datagram_received method
+                    // Now state is not borrowed, so sendto can work
+                    transport.call_datagram_received(py, &buf[..size], addr);
+                },
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    // No more data available
+                    break;
+                },
+                Err(err) if err.kind() == ErrorKind::Interrupted => {
+                    // Interrupted by signal, continue
+                    continue;
+                },
+                Err(err) => {
+                    // Other error - call error_received and close
+                    let py_err = pyo3::exceptions::PyOSError::new_err(err.to_string());
+                    transport.call_error_received(py, py_err);
+                    event_loop.udp_socket_close(py, self.fd);
+                    break;
+                },
+            }
+        }
+    }
+}

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,12 +1,12 @@
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd};
 
-use mio::net::UdpSocket;
-use pyo3::{IntoPyObject, prelude::*, types::PyBytes};
+use mio::{Interest, net::UdpSocket};
+use pyo3::{IntoPyObject, IntoPyObjectExt, prelude::*, types::PyBytes};
 use std::{
     borrow::Cow,
     cell::RefCell,
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     io::ErrorKind,
     net::{IpAddr, SocketAddr},
     str::FromStr,
@@ -16,12 +16,15 @@ use std::{
 use crate::{
     event_loop::{EventLoop, EventLoopRunState},
     handles::Handle,
+    log::LogExc,
     sock::SocketWrapper,
 };
 
 struct UDPTransportState {
     socket: UdpSocket,
     remote_addr: Option<SocketAddr>,
+    write_buf: VecDeque<(Box<[u8]>, SocketAddr)>,
+    write_buf_dsize: usize,
 }
 
 #[pyclass(frozen, unsendable, module = "rloop._rloop")]
@@ -31,8 +34,11 @@ pub(crate) struct UDPTransport {
     pyloop: Py<EventLoop>,
     // atomics
     closing: atomic::AtomicBool,
+    water_hi: atomic::AtomicUsize,
+    water_lo: atomic::AtomicUsize,
     // py protocol fields
     proto: PyObject,
+    proto_paused: atomic::AtomicBool,
     protom_conn_lost: PyObject,
     protom_datagram_received: PyObject,
     protom_error_received: PyObject,
@@ -51,7 +57,15 @@ impl UDPTransport {
         remote_addr: Option<SocketAddr>,
     ) -> Self {
         let fd = socket.as_raw_fd() as usize;
-        let state = UDPTransportState { socket, remote_addr };
+        let state = UDPTransportState {
+            socket,
+            remote_addr,
+            write_buf: VecDeque::new(),
+            write_buf_dsize: 0,
+        };
+
+        let wh = 1024 * 64;
+        let wl = wh / 4;
 
         let protom_conn_lost = pyproto.getattr(pyo3::intern!(py, "connection_lost")).unwrap().unbind();
         let protom_datagram_received = pyproto
@@ -66,7 +80,10 @@ impl UDPTransport {
             state: RefCell::new(state),
             pyloop,
             closing: false.into(),
+            water_hi: wh.into(),
+            water_lo: wl.into(),
             proto,
+            proto_paused: false.into(),
             protom_conn_lost,
             protom_datagram_received,
             protom_error_received,
@@ -101,6 +118,38 @@ impl UDPTransport {
         Ok(rself.proto.clone_ref(py))
     }
 
+    #[inline]
+    fn write_buf_size_decr(pyself: &Py<Self>, py: Python) {
+        let rself = pyself.borrow(py);
+        if rself.state.borrow().write_buf_dsize <= rself.water_lo.load(atomic::Ordering::Relaxed)
+            && rself
+                .proto_paused
+                .compare_exchange(true, false, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed)
+                .is_ok()
+        {
+            Self::proto_resume(pyself, py);
+        }
+    }
+
+    #[inline]
+    fn close_from_write_handle(&self, py: Python, errored: bool) -> bool {
+        if self.closing.load(atomic::Ordering::Relaxed) {
+            _ = self.protom_conn_lost.call1(
+                py,
+                #[allow(clippy::obfuscated_if_else)]
+                (errored
+                    .then(|| {
+                        pyo3::exceptions::PyRuntimeError::new_err("socket transport failed")
+                            .into_py_any(py)
+                            .unwrap()
+                    })
+                    .unwrap_or_else(|| py.None()),),
+            );
+            return true;
+        }
+        false
+    }
+
     #[inline(always)]
     fn call_conn_lost(&self, py: Python, exc: Option<PyErr>) {
         _ = self.protom_conn_lost.call1(py, (exc,));
@@ -116,6 +165,90 @@ impl UDPTransport {
     #[inline]
     fn call_error_received(&self, py: Python, exc: PyErr) {
         _ = self.protom_error_received.call1(py, (exc,));
+    }
+
+    fn write(pyself: &Py<Self>, py: Python, data: &[u8], addr: SocketAddr) {
+        let rself = pyself.borrow(py);
+        let mut state = rself.state.borrow_mut();
+
+        let buf_added = match state.write_buf_dsize {
+            0 => {
+                match rself.state.borrow().socket.send_to(data, addr) {
+                    Ok(written) if written == data.len() => 0,
+                    Ok(written) => {
+                        state.write_buf.push_back(((&data[written..]).into(), addr));
+                        data.len() - written
+                    }
+                    Err(err)
+                        if err.kind() == std::io::ErrorKind::Interrupted
+                            || err.kind() == std::io::ErrorKind::WouldBlock =>
+                    {
+                        state.write_buf.push_back((data.into(), addr));
+                        data.len()
+                    }
+                    Err(err) => {
+                        if state.write_buf_dsize > 0 {
+                            // reset buf_dsize?
+                            rself.pyloop.get().udp_socket_rem(rself.fd, Interest::WRITABLE);
+                        }
+                        if rself
+                            .closing
+                            .compare_exchange(false, true, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed)
+                            .is_ok()
+                        {
+                            rself.pyloop.get().udp_socket_rem(rself.fd, Interest::READABLE);
+                        }
+                        rself.call_conn_lost(py, Some(pyo3::exceptions::PyOSError::new_err(err.to_string())));
+                        0
+                    }
+                }
+            }
+            _ => {
+                state.write_buf.push_back((data.into(), addr));
+                data.len()
+            }
+        };
+
+        if buf_added > 0 {
+            if state.write_buf_dsize == 0 {
+                rself.pyloop.get().udp_socket_add(rself.fd, Interest::WRITABLE);
+            }
+            state.write_buf_dsize += buf_added;
+            if state.write_buf_dsize > rself.water_hi.load(atomic::Ordering::Relaxed)
+                && rself
+                    .proto_paused
+                    .compare_exchange(false, true, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed)
+                    .is_ok()
+            {
+                Self::proto_pause(pyself, py);
+            }
+        }
+    }
+
+    fn proto_pause(pyself: &Py<Self>, py: Python) {
+        let rself = pyself.borrow(py);
+        if let Err(err) = rself.proto.call_method0(py, pyo3::intern!(py, "pause_writing")) {
+            let err_ctx = LogExc::transport(
+                err,
+                "protocol.pause_writing() failed".into(),
+                rself.proto.clone_ref(py),
+                pyself.clone_ref(py).into_any(),
+            );
+            _ = rself.pyloop.get().log_exception(py, err_ctx);
+        }
+    }
+
+    fn proto_resume(pyself: &Py<Self>, py: Python) {
+        let rself = pyself.borrow(py);
+        if let Err(err) = rself.proto.call_method0(py, pyo3::intern!(py, "resume_writing")) {
+            let err_ctx = LogExc::transport(
+                err,
+                "protocol.resume_writing() failed".into(),
+                rself.proto.clone_ref(py),
+                pyself.clone_ref(py).into_any(),
+            );
+            _ = rself.pyloop.get().log_exception(py, err_ctx);
+        }
     }
 }
 
@@ -150,17 +283,24 @@ impl UDPTransport {
             return;
         }
 
-        self.pyloop.get().udp_socket_rem(self.fd);
-        self.call_conn_lost(py, None);
+        let event_loop = self.pyloop.get();
+        event_loop.udp_socket_rem(self.fd, Interest::READABLE);
+        if self.state.borrow().write_buf_dsize == 0 {
+            event_loop.udp_socket_rem(self.fd, Interest::WRITABLE);
+            self.call_conn_lost(py, None);
+        }
     }
 
     fn abort(&self, py: Python) {
+        if self.state.borrow().write_buf_dsize > 0 {
+            self.pyloop.get().udp_socket_rem(self.fd, Interest::WRITABLE);
+        }
         if self
             .closing
             .compare_exchange(false, true, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed)
             .is_ok()
         {
-            self.pyloop.get().udp_socket_rem(self.fd);
+            self.pyloop.get().udp_socket_rem(self.fd, Interest::READABLE);
         }
         self.call_conn_lost(py, None);
     }
@@ -175,28 +315,72 @@ impl UDPTransport {
         self.proto.clone_ref(py)
     }
 
-    // TODO: implement buffered write
-    fn sendto(&self, data: Cow<[u8]>, addr: Option<(String, u16)>) -> PyResult<()> {
-        if self.closing.load(atomic::Ordering::Relaxed) {
+    #[pyo3(signature = (high = None, low = None))]
+    fn set_write_buffer_limits(pyself: Py<Self>, py: Python, high: Option<usize>, low: Option<usize>) -> PyResult<()> {
+        let wh = match high {
+            None => match low {
+                None => 1024 * 64,
+                Some(v) => v * 4,
+            },
+            Some(v) => v,
+        };
+        let wl = match low {
+            None => wh / 4,
+            Some(v) => v,
+        };
+
+        if wh < wl {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "high must be >= low must be >= 0",
+            ));
+        }
+
+        let rself = pyself.borrow(py);
+        rself.water_hi.store(wh, atomic::Ordering::Relaxed);
+        rself.water_lo.store(wl, atomic::Ordering::Relaxed);
+
+        if rself.state.borrow().write_buf_dsize > wh
+            && rself
+                .proto_paused
+                .compare_exchange(false, true, atomic::Ordering::Relaxed, atomic::Ordering::Relaxed)
+                .is_ok()
+        {
+            Self::proto_pause(&pyself, py);
+        }
+
+        Ok(())
+    }
+
+    fn get_write_buffer_size(&self) -> usize {
+        self.state.borrow().write_buf_dsize
+    }
+
+    fn get_write_buffer_limits(&self) -> (usize, usize) {
+        (
+            self.water_lo.load(atomic::Ordering::Relaxed),
+            self.water_hi.load(atomic::Ordering::Relaxed),
+        )
+    }
+
+    fn sendto(pyself: Py<Self>, py: Python, data: Cow<[u8]>, addr: Option<(String, u16)>) -> PyResult<()> {
+        let rself = pyself.borrow(py);
+
+        if rself.closing.load(atomic::Ordering::Relaxed) {
             return Err(pyo3::exceptions::PyRuntimeError::new_err(
                 "Cannot send on closing transport",
             ));
         }
+        if data.is_empty() {
+            return Ok(());
+        }
 
         match addr
             .map(|v| SocketAddr::new(IpAddr::from_str(&v.0).unwrap(), v.1))
-            .or_else(|| self.state.borrow().remote_addr)
+            .or_else(|| rself.state.borrow().remote_addr)
         {
             Some(addr) => {
-                // Temporarily borrow just for the send operation
-                match self.state.borrow().socket.send_to(&data, addr) {
-                    Ok(_) => Ok(()),
-                    Err(err) if err.kind() == ErrorKind::WouldBlock => {
-                        // FIXME: For UDP, we don't buffer writes like TCP - just drop the packet or return error
-                        Err(pyo3::exceptions::PyBlockingIOError::new_err("Socket would block"))
-                    }
-                    Err(err) => Err(pyo3::exceptions::PyOSError::new_err(err.to_string())),
-                }
+                Self::write(&pyself, py, &data, addr);
+                Ok(())
             }
             None => Err(pyo3::exceptions::PyValueError::new_err("No remote address specified")),
         }
@@ -204,13 +388,7 @@ impl UDPTransport {
 }
 
 pub(crate) struct UDPReadHandle {
-    fd: usize,
-}
-
-impl UDPReadHandle {
-    pub(crate) fn new(fd: usize) -> Self {
-        Self { fd }
-    }
+    pub fd: usize,
 }
 
 impl Handle for UDPReadHandle {
@@ -239,10 +417,74 @@ impl Handle for UDPReadHandle {
                     // Other error - call error_received and close
                     let py_err = pyo3::exceptions::PyOSError::new_err(err.to_string());
                     transport.call_error_received(py, py_err);
-                    event_loop.udp_socket_close(py, self.fd);
+                    event_loop.udp_socket_close(self.fd);
                     break;
                 }
             }
+        }
+    }
+}
+
+pub(crate) struct UDPWriteHandle {
+    pub fd: usize,
+}
+
+impl UDPWriteHandle {
+    #[inline]
+    fn write(&self, transport: &UDPTransport) -> Option<usize> {
+        let mut ret = 0;
+        let mut state = transport.state.borrow_mut();
+
+        while let Some((data, addr)) = state.write_buf.pop_front() {
+            match state.socket.send_to(&data, addr) {
+                Ok(written) if written < data.len() => {
+                    state.write_buf.push_front(((&data[written..]).into(), addr));
+                    ret += written;
+                    break;
+                }
+                Ok(written) => ret += written,
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => {
+                    state.write_buf.push_front((data, addr));
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    state.write_buf.push_front((data, addr));
+                    break;
+                }
+                _ => {
+                    state.write_buf.clear();
+                    state.write_buf_dsize = 0;
+                    return None;
+                }
+            }
+        }
+        state.write_buf_dsize -= ret;
+        Some(ret)
+    }
+}
+
+impl Handle for UDPWriteHandle {
+    fn run(&self, py: Python, event_loop: &EventLoop, _state: &mut EventLoopRunState) {
+        let pytransport = event_loop.get_udp_transport(self.fd, py);
+        let transport = pytransport.borrow(py);
+        let stream_close;
+
+        if let Some(written) = self.write(&transport) {
+            if written > 0 {
+                UDPTransport::write_buf_size_decr(&pytransport, py);
+            }
+            stream_close = match transport.state.borrow().write_buf.is_empty() {
+                true => transport.close_from_write_handle(py, false),
+                false => false,
+            };
+        } else {
+            stream_close = transport.close_from_write_handle(py, true);
+        }
+
+        if transport.state.borrow().write_buf.is_empty() {
+            event_loop.udp_socket_rem(self.fd, Interest::WRITABLE);
+        }
+        if stream_close {
+            event_loop.udp_socket_close(self.fd);
         }
     }
 }

--- a/tests/udp/test_udp.py
+++ b/tests/udp/test_udp.py
@@ -40,9 +40,7 @@ def test_create_datagram_endpoint_sock(loop):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind(('127.0.0.1', 0))
     sock.setblocking(False)  # Make socket non-blocking
-    fut = loop.create_datagram_endpoint(
-        lambda: DatagramProto(create_future=True, loop=loop),
-        sock=sock)
+    fut = loop.create_datagram_endpoint(lambda: DatagramProto(create_future=True, loop=loop), sock=sock)
     transport, protocol = loop.run_until_complete(fut)
     transport.close()
     loop.run_until_complete(protocol.done)
@@ -51,9 +49,7 @@ def test_create_datagram_endpoint_sock(loop):
 
 @pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason='no UDS')
 def test_create_datagram_endpoint_sock_unix(loop):
-    fut = loop.create_datagram_endpoint(
-        lambda: DatagramProto(create_future=True, loop=loop),
-        family=socket.AF_UNIX)
+    fut = loop.create_datagram_endpoint(lambda: DatagramProto(create_future=True, loop=loop), family=socket.AF_UNIX)
     transport, protocol = loop.run_until_complete(fut)
     # Check that the socket family is AF_UNIX using get_extra_info
     sock_info = transport.get_extra_info('socket')
@@ -65,8 +61,8 @@ def test_create_datagram_endpoint_sock_unix(loop):
 
 def test_create_datagram_endpoint_local_addr(loop):
     fut = loop.create_datagram_endpoint(
-        lambda: DatagramProto(create_future=True, loop=loop),
-        local_addr=('127.0.0.1', 0))
+        lambda: DatagramProto(create_future=True, loop=loop), local_addr=('127.0.0.1', 0)
+    )
     transport, protocol = loop.run_until_complete(fut)
     transport.close()
     loop.run_until_complete(protocol.done)
@@ -75,8 +71,8 @@ def test_create_datagram_endpoint_local_addr(loop):
 
 def test_create_datagram_endpoint_remote_addr(loop):
     fut = loop.create_datagram_endpoint(
-        lambda: DatagramProto(create_future=True, loop=loop),
-        remote_addr=('127.0.0.1', 12345))
+        lambda: DatagramProto(create_future=True, loop=loop), remote_addr=('127.0.0.1', 12345)
+    )
     transport, protocol = loop.run_until_complete(fut)
     transport.close()
     loop.run_until_complete(protocol.done)

--- a/tests/udp/test_udp.py
+++ b/tests/udp/test_udp.py
@@ -1,9 +1,7 @@
 import asyncio
+import socket
 
-
-# import socket
-
-# import pytest
+import pytest
 
 
 class DatagramProto(asyncio.DatagramProtocol):
@@ -38,39 +36,48 @@ class DatagramProto(asyncio.DatagramProtocol):
             self.done.set_result(None)
 
 
-# def test_create_datagram_endpoint_sock(loop):
-#     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-#     sock.bind(('127.0.0.1', 0))
-#     fut = loop.create_datagram_endpoint(
-#         lambda: DatagramProto(create_future=True, loop=loop),
-#         sock=sock)
-#     transport, protocol = loop.run_until_complete(fut)
-#     transport.close()
-#     loop.run_until_complete(protocol.done)
-#     assert protocol.state == 'CLOSED'
+def test_create_datagram_endpoint_sock(loop):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(('127.0.0.1', 0))
+    sock.setblocking(False)  # Make socket non-blocking
+    fut = loop.create_datagram_endpoint(
+        lambda: DatagramProto(create_future=True, loop=loop),
+        sock=sock)
+    transport, protocol = loop.run_until_complete(fut)
+    transport.close()
+    loop.run_until_complete(protocol.done)
+    assert protocol.state == 'CLOSED'
 
 
-# @pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason='no UDS')
-# def test_create_datagram_endpoint_sock_unix(loop):
-#     fut = loop.create_datagram_endpoint(
-#         lambda: DatagramProto(create_future=True, loop=loop),
-#         family=socket.AF_UNIX)
-#     transport, protocol = loop.run_until_complete(fut)
-#     assert transport._sock.family == socket.AF_UNIX
-#     transport.close()
-#     loop.run_until_complete(protocol.done)
-#     assert protocol.state == 'CLOSED'
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason='no UDS')
+def test_create_datagram_endpoint_sock_unix(loop):
+    fut = loop.create_datagram_endpoint(
+        lambda: DatagramProto(create_future=True, loop=loop),
+        family=socket.AF_UNIX)
+    transport, protocol = loop.run_until_complete(fut)
+    # Check that the socket family is AF_UNIX using get_extra_info
+    sock_info = transport.get_extra_info('socket')
+    assert sock_info.family == socket.AF_UNIX
+    transport.close()
+    loop.run_until_complete(protocol.done)
+    assert protocol.state == 'CLOSED'
 
 
-# def test_create_datagram_endpoint_existing_sock_unix(loop):
-#     with _unix_socket_path() as path:
-#         sock = socket.socket(socket.AF_UNIX, type=socket.SOCK_DGRAM)
-#         sock.bind(path)
-#         sock.close()
+def test_create_datagram_endpoint_local_addr(loop):
+    fut = loop.create_datagram_endpoint(
+        lambda: DatagramProto(create_future=True, loop=loop),
+        local_addr=('127.0.0.1', 0))
+    transport, protocol = loop.run_until_complete(fut)
+    transport.close()
+    loop.run_until_complete(protocol.done)
+    assert protocol.state == 'CLOSED'
 
-#         coro = loop.create_datagram_endpoint(
-#             lambda: DatagramProto(create_future=True, loop=loop),
-#             path, family=socket.AF_UNIX)
-#         transport, protocol = loop.run_until_complete(coro)
-#         transport.close()
-#         loop.run_until_complete(protocol.done)
+
+def test_create_datagram_endpoint_remote_addr(loop):
+    fut = loop.create_datagram_endpoint(
+        lambda: DatagramProto(create_future=True, loop=loop),
+        remote_addr=('127.0.0.1', 12345))
+    transport, protocol = loop.run_until_complete(fut)
+    transport.close()
+    loop.run_until_complete(protocol.done)
+    assert protocol.state == 'CLOSED'


### PR DESCRIPTION
This pull request adds full support for UDP (datagram) transports to the event loop, including both the Python and Rust sides. It implements UDP socket creation, management, event dispatch, and exposes a `UDPTransport` class to Python. The changes also include comprehensive tests for UDP endpoint creation, both with new and existing sockets, and for various address families.

The most important changes are:

**UDP Transport Implementation:**

* Added a new `UDPTransport` class in `src/udp.rs`, including methods for sending and receiving datagrams, handling protocol callbacks, and managing socket state. Also introduced a `UDPHandle` for event processing.
* Implemented the `_udp_conn` function in `EventLoop` to create and register UDP transports, handling socket setup and protocol attachment.
* Added UDP socket management methods to `EventLoop` (`udp_socket_add`, `udp_socket_rem`, `udp_socket_close`, `get_udp_transport`) and a `udp_transports` map to track active UDP transports. [[1]](diffhunk://#diff-f5a20b394a5ba72e0e625bac291ac8e2fa04a59b2801dae39b277499d14729fdR419-R448) [[2]](diffhunk://#diff-f5a20b394a5ba72e0e625bac291ac8e2fa04a59b2801dae39b277499d14729fdR78) [[3]](diffhunk://#diff-f5a20b394a5ba72e0e625bac291ac8e2fa04a59b2801dae39b277499d14729fdR677)

**Event Loop Integration:**

* Extended the `IOHandle` enum and event dispatch logic to support UDP sockets, including a handler for readable UDP events. [[1]](diffhunk://#diff-f5a20b394a5ba72e0e625bac291ac8e2fa04a59b2801dae39b277499d14729fdR30) [[2]](diffhunk://#diff-f5a20b394a5ba72e0e625bac291ac8e2fa04a59b2801dae39b277499d14729fdR155) [[3]](diffhunk://#diff-f5a20b394a5ba72e0e625bac291ac8e2fa04a59b2801dae39b277499d14729fdR261-R268)
* Registered the new UDP module in `src/lib.rs` for inclusion in the Python extension.

**Python API and Testing:**

* Implemented `create_datagram_endpoint` in `rloop/loop.py` to support creating UDP endpoints with various socket/address options, including error handling and socket configuration.
* Added and enabled comprehensive UDP tests in `tests/udp/test_udp.py`, covering creation with existing sockets, UNIX sockets, and both local and remote addresses. [[1]](diffhunk://#diff-5bb8242131ad4770d8af8e4e3cd5e1cfaf6c9f547c59089d61ddcb483e894633L41-R83) [[2]](diffhunk://#diff-5bb8242131ad4770d8af8e4e3cd5e1cfaf6c9f547c59089d61ddcb483e894633R2-R4)
