### PR TITLE
Handle negative values on `call_later`

### DIFF
--- a/rloop/loop.py
+++ b/rloop/loop.py
@@ -215,8 +215,6 @@ class RLoop(__BaseLoop, __asyncio.AbstractEventLoop):
     #     raise NotImplementedError
 
     def call_later(self, delay, callback, *args, context=None) -> Union[CBHandle, TimerHandle]:
-        if delay <= 0:
-            return self.call_soon(callback, *args, context=context or _copy_context())
         delay = round(delay * 1_000_000)
         return self._call_later(delay, callback, args, context or _copy_context())
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -102,10 +102,12 @@ impl EventLoop {
         } else {
             let guard_sched = self.handles_sched.lock().unwrap();
             if let Some(timer) = guard_sched.peek() {
-                let tick = Instant::now().duration_since(self.epoch).as_micros();
+                let tick = Instant::now().duration_since(self.epoch).as_micros() as i128;
                 if timer.when > tick {
                     let dt = (timer.when - tick) as u64;
                     sched_time = Some(dt);
+                } else if timer.when < 0 {
+                    sched_time = Some(0);
                 }
             }
         }
@@ -163,7 +165,7 @@ impl EventLoop {
         {
             let mut guard_sched = self.handles_sched.lock().unwrap();
             if let Some(timer) = guard_sched.peek() {
-                let tick = Instant::now().duration_since(self.epoch).as_micros();
+                let tick = Instant::now().duration_since(self.epoch).as_micros() as i128;
                 if timer.when <= tick {
                     while let Some(timer) = guard_sched.peek() {
                         if timer.when > tick {
@@ -570,7 +572,7 @@ impl EventLoop {
 
     #[allow(clippy::missing_errors_doc)]
     pub fn schedule_later0(&self, delay: Duration, callback: Py<PyAny>, context: Option<Py<PyAny>>) -> Result<()> {
-        let when = (Instant::now().duration_since(self.epoch) + delay).as_micros();
+        let when = (Instant::now().duration_since(self.epoch) + delay).as_micros() as i128;
         let handle = Python::attach(|py| {
             Py::new(
                 py,
@@ -601,7 +603,7 @@ impl EventLoop {
         arg: Py<PyAny>,
         context: Option<Py<PyAny>>,
     ) -> Result<()> {
-        let when = (Instant::now().duration_since(self.epoch) + delay).as_micros();
+        let when = (Instant::now().duration_since(self.epoch) + delay).as_micros() as i128;
         let handle = Python::attach(|py| {
             Py::new(
                 py,
@@ -632,7 +634,7 @@ impl EventLoop {
         args: Py<PyAny>,
         context: Option<Py<PyAny>>,
     ) -> Result<()> {
-        let when = (Instant::now().duration_since(self.epoch) + delay).as_micros();
+        let when = (Instant::now().duration_since(self.epoch) + delay).as_micros() as i128;
         let handle = Python::attach(|py| {
             Py::new(
                 py,
@@ -659,7 +661,7 @@ impl EventLoop {
     pub fn schedule_handle(&self, handle: impl Handle + Send + 'static, delay: Option<Duration>) -> Result<()> {
         match delay {
             Some(delay) => {
-                let when = (Instant::now().duration_since(self.epoch) + delay).as_micros();
+                let when = (Instant::now().duration_since(self.epoch) + delay).as_micros() as i128;
                 let timer = Timer {
                     handle: Box::new(handle),
                     when,
@@ -967,12 +969,12 @@ impl EventLoop {
     fn _call_later(
         &self,
         py: Python,
-        delay: u64,
+        delay: i64,
         callback: Py<PyAny>,
         args: Py<PyAny>,
         context: Py<PyAny>,
     ) -> TimerHandle {
-        let when = Instant::now().duration_since(self.epoch).as_micros() + u128::from(delay);
+        let when = (Instant::now().duration_since(self.epoch).as_micros() as i128) + i128::from(delay);
         let handle = Py::new(py, CBHandle::new(callback, args, context)).unwrap();
         let timer = Timer {
             handle: Box::new(handle.clone_ref(py)),

--- a/src/handles.rs
+++ b/src/handles.rs
@@ -179,7 +179,7 @@ pub(crate) struct TimerHandle {
 
 impl TimerHandle {
     #[allow(clippy::cast_precision_loss)]
-    pub(crate) fn new(handle: Py<CBHandle>, when: u128) -> Self {
+    pub(crate) fn new(handle: Py<CBHandle>, when: i128) -> Self {
         Self {
             handle,
             when: (when as f64) / 1_000_000.0,

--- a/src/time.rs
+++ b/src/time.rs
@@ -4,7 +4,7 @@ use crate::handles::BoxedHandle;
 
 pub(crate) struct Timer {
     pub handle: BoxedHandle,
-    pub when: u128,
+    pub when: i128,
 }
 
 impl PartialEq for Timer {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,16 @@
+import asyncio
+
 import pytest
 
 import rloop
 
 
-@pytest.fixture(scope='function')
-def loop():
-    return rloop.new_event_loop()
+EVENT_LOOPS = [
+    asyncio.new_event_loop,
+    rloop.new_event_loop,
+]
+
+
+@pytest.fixture(scope='function', params=EVENT_LOOPS, ids=lambda x: type(x()))
+def loop(request):
+    return request.param()

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -42,10 +42,17 @@ def test_call_later_negative(loop):
     def cb(arg):
         calls.append(arg)
 
-    loop.call_later(-1.0, cb, 1)
-    loop.call_later(-2.0, cb, 2)
-    run_loop(loop)
-    assert calls == [1, 2]
+    def stop():
+        loop.stop()
+
+    loop.call_later(-1.0, cb, -1)
+    loop.call_later(-2.0, cb, -2)
+    loop.call_later(0.5, cb, 5)
+    loop.call_later(0.3, cb, 3)
+    loop.call_later(0.7, stop)
+
+    loop.run_forever()
+    assert calls == [-2, -1, 3, 5]
 
 
 def test_call_at(loop):


### PR DESCRIPTION
This started as a simple `parametrize`  improvement over tests.

That lead to perceive a discrepancy between call_later of Asyncio and RLoop.

Instead of XFailing the RLoop version, why not fix it?

Turns out to be simple, if it is ok to not call_soon the negative-scheduled coros.

I had to allow negative values, and there is some lossy conversations from u128 to i128, but this part is fine as nothing bigger than i64 comes from the Python side anyway.

Updates on README will follow after a positive code-review on this PR