### PR TITLE
Ensure parity with Asyncio loop on tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,16 @@
+import asyncio
+
 import pytest
 
 import rloop
 
 
-@pytest.fixture(scope='function')
-def loop():
-    return rloop.new_event_loop()
+EVENT_LOOPS = [
+    asyncio.new_event_loop,
+    rloop.new_event_loop,
+]
+
+
+@pytest.fixture(scope='function', params=EVENT_LOOPS, ids=lambda x: type(x()))
+def loop(request):
+    return request.param()

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -1,5 +1,7 @@
 import threading
 
+import pytest
+
 
 def run_loop(loop):
     async def run():
@@ -37,6 +39,9 @@ def test_call_later(loop):
 
 
 def test_call_later_negative(loop):
+    if type(loop).__module__.startswith('asyncio'):
+        pytest.skip('Asyncio std loop schedule negatives differently.')
+
     calls = []
 
     def cb(arg):


### PR DESCRIPTION
By running every test with RLoop and Asyncio we ensure similar behaviour, including across Python versions.

When they differ by design, like on `test_call_later_negative`, a `pytest.skip` allows an explicit explanation.